### PR TITLE
Use napari default blending if not set by Category

### DIFF
--- a/napari_assistant/_categories.py
+++ b/napari_assistant/_categories.py
@@ -27,7 +27,7 @@ class Category:
     exclude: Sequence[str] = field(default_factory=tuple)
     # visualization
     color_map : str = "gray"
-    blending : str = "translucent"
+    blending : str = None
     tool_tip : str = ""
     tools_menu : str = None
     auto_call : bool = True
@@ -147,7 +147,6 @@ CATEGORIES = {
         include=("label measurement", "map"),
         exclude=("combine",),
         color_map="turbo",
-        blending="translucent",
         tools_menu="None",
     ),
     "Measure labeled image": Category(
@@ -159,7 +158,6 @@ CATEGORIES = {
         include=("combine","label measurement", "map",),
         exclude=("label comparison",),
         color_map="turbo",
-        blending="translucent",
         tools_menu="None",
     ),
     "Compare label images": Category(
@@ -172,7 +170,6 @@ CATEGORIES = {
         include=("combine","label measurement", "map", "label comparison",),
         exclude=(),
         color_map="turbo",
-        blending="translucent",
         tools_menu="None",
     ),
     "Label neighbor filters": Category(
@@ -183,7 +180,6 @@ CATEGORIES = {
         default_values=[1, 100],
         include=("neighbor",),
         color_map="turbo",
-        blending="translucent",
         tools_menu="Label neighbor filters",
     ),
     "Label filters": Category(


### PR DESCRIPTION
This PR adresses https://github.com/haesleinhuepf/napari-assistant/issues/18
Basically, instead of setting a default blending in `napari-assisant` Category class, the default is left as `None` such that it is handled by napari.
In napari 0.4.15 this will still be `translucent` but in napari 0.4.16 the new default is `translucent_no_depth`.
Specific categories that had previously hard-set `translucent` are also now just using the default, because it wasn't clear that they require depth checking (or not).
Categories that specifically set other blending modes, such as Mesh that set `additive`, continue to use their custom modes.

I tested this locally with both 0.4.15 and 0.4.16 testing a few of the different workflow operations, including the workflow originally posted in the napari issue https://github.com/napari/napari/issues/4618
Everything behaved correctly.
