### PR TITLE
Stop load_workflow when nothing is loaded

### DIFF
--- a/napari_assistant/_gui/_Assistant.py
+++ b/napari_assistant/_gui/_Assistant.py
@@ -367,6 +367,9 @@ class Assistant(QWidget):
 
         if not filename:
             filename, _ = QFileDialog.getOpenFileName(self, "Import workflow ...", ".", "*.yaml")
+        if filename == '':
+            # nothing loaded
+            return
         self.workflow = _io_yaml_v1.load_workflow(filename)
 
         w_dw = initialise_root_functions(


### PR DESCRIPTION
When a user close `getOpenFileName` without specifying any yaml file, `load_workflow` made errors.
I have added the validation code whether file is really chosen.