### PR TITLE
Include pyrsistent in setup.cfg & requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ jupyter
 pandas
 napari-time-slicer>=0.4.4
 napari-workflows>=0.2.4
+pyrsistent

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ install_requires =
     pandas
     napari-time-slicer>=0.4.8
     napari-workflows>=0.2.4
+    pyrsistent
 
 
 [options.entry_points]


### PR DESCRIPTION
This package imports from `pyrsistent`:
https://github.com/haesleinhuepf/napari-assistant/blob/e1b9487c2bac5dc0c3dffcc7edd303e2ed0c9e69/napari_assistant/_gui/_button_grid.py#L1

But it doesn't depend on it, so neither conda-forge nor pip installs work with error:
```
Traceback (most recent call last):
  File "/Users/piotrsobolewski/Dev/miniforge3/envs/nap-test/bin/naparia", line 5, in <module>
    from napari_assistant import main
  File "/Users/piotrsobolewski/Dev/miniforge3/envs/nap-test/lib/python3.10/site-packages/napari_assistant/__init__.py", line 1, in <module>
    from ._gui import Assistant
  File "/Users/piotrsobolewski/Dev/miniforge3/envs/nap-test/lib/python3.10/site-packages/napari_assistant/_gui/__init__.py", line 1, in <module>
    from ._Assistant import Assistant
  File "/Users/piotrsobolewski/Dev/miniforge3/envs/nap-test/lib/python3.10/site-packages/napari_assistant/_gui/_Assistant.py", line 10, in <module>
    from ._button_grid import ButtonGrid, _get_highlight_brush, _get_background_brush
  File "/Users/piotrsobolewski/Dev/miniforge3/envs/nap-test/lib/python3.10/site-packages/napari_assistant/_gui/_button_grid.py", line 1, in <module>
    from pyrsistent import b
ModuleNotFoundError: No module named 'pyrsistent'
```
See also: https://napari.zulipchat.com/#narrow/stream/212875-general/topic/napari.20assistant.20not.20showing.20up

In this PR, I add it to setup.cfg and the requirements.