### PR TITLE
remove import of pyresistant

### DIFF
--- a/napari_assistant/_gui/_button_grid.py
+++ b/napari_assistant/_gui/_button_grid.py
@@ -1,4 +1,3 @@
-from pyrsistent import b
 from qtpy.QtCore import QSize
 from qtpy.QtGui import QIcon, QColor, QBrush
 from qtpy.QtWidgets import QListWidget, QListWidgetItem

--- a/tox.ini
+++ b/tox.ini
@@ -11,9 +11,9 @@ python =
     
 [gh-actions:env]
 PLATFORM =
-    ubuntu-latest: linux
-#    macos-latest: macos
-#    windows-latest: windows
+#    ubuntu-latest: linux
+    macos-latest: macos
+    windows-latest: windows
 
 [testenv]
 platform = 


### PR DESCRIPTION
I'm removing the import of pyresistant because it seems not necessary. I'm going to merge and release immediately as it prevents installation/function on a couple of user's computers.

@Cryaaa please let me know if you think this was a bad idea. You introduced this line [apparently](https://github.com/haesleinhuepf/napari-assistant/blame/e1b9487c2bac5dc0c3dffcc7edd303e2ed0c9e69/napari_assistant/_gui/_button_grid.py#L1)

closes #46 