### PR TITLE
remove print statement of available functions at startup

### DIFF
--- a/napari_assistant/_categories.py
+++ b/napari_assistant/_categories.py
@@ -408,8 +408,6 @@ def collect_from_pyclesperanto_if_installed():
     except ImportError:
         print("Assistant skips harvesting pyclesperanto_prototype as it's not installed.")
 
-    print(available_already)
-
     return result
 
 


### PR DESCRIPTION
This new print statement has resulted in users confused about the new print out in the console. It also does not seem that informative, since the information is the same on each running of the assistant (unless of course a new compatible library is installed). 

Since this is useful information on the developer side, then consider allowing it to be called from a separate method. Maybe this was just for debugging purposes at the time.